### PR TITLE
Fix points for holding patterns

### DIFF
--- a/FlightPatternDetection.DTO/HoldingResult.cs
+++ b/FlightPatternDetection.DTO/HoldingResult.cs
@@ -1,4 +1,6 @@
-﻿namespace FlightPatternDetection.DTO
+﻿using FlightPatternDetection.DTO.NavDBEntities;
+
+namespace FlightPatternDetection.DTO
 {
     public class HoldingResult
     {
@@ -7,5 +9,6 @@
         public HoldingDirection Direction { get; set; }
         public int Altitude { get; set; }
         public int Laps { get; set; }
+        public EWayPoint FixPoint { get; set; }
     }
 }

--- a/GuiWebApp/Pages/FlightVisualizer.razor
+++ b/GuiWebApp/Pages/FlightVisualizer.razor
@@ -113,7 +113,8 @@
                     {
                         <p class="m-0">Laps: @holdingResult.Laps</p>
                         <p class="m-0">Altitude: @holdingResult.Altitude Feet</p>   
-                        <p class="m-0">Direction: @(holdingResult.Direction == HoldingDirection.Left ? "Left" : "Right")</p>   
+                        <p class="m-0">Direction: @(holdingResult.Direction == HoldingDirection.Left ? "Left" : "Right")</p>
+                        <p class="m-0">Fix point: @holdingResult.FixPoint.Name</p>
                     }
                     <p>Detection took: @holdingResult.DetectionTime.TotalMilliseconds.ToString("0.00", CultureInfo.InvariantCulture) ms.</p>
                 </div>
@@ -217,7 +218,7 @@
             var data = await res.Content.ReadFromJsonAsync<List<TrafficPosition>>();
             var lastPoint = data.Last();
 
-            var result = await httpClient.GetAsync($"NavDb/Waypoints?lat={lastPoint.Lat}&lng={lastPoint.Lon}");
+            var result = await httpClient.GetAsync($"NavDb/Waypoints?lat={lastPoint.Lat}&lng={lastPoint.Lon}&radius=1");
 
             if (!result.IsSuccessStatusCode)
             {

--- a/PatternDetectionEngine/DetectionEngine.cs
+++ b/PatternDetectionEngine/DetectionEngine.cs
@@ -186,16 +186,14 @@ public class DetectionEngine
             IsCloseEnough(waypoint, firstInversionPoint, pointBuffer)
         ).ToList();
         
+        var closePoints = waypointsAroundHolding.Where(p => 
+            holdingPoints.Any(h => IsCloseEnough(p, h, 0.025))
+        ).ToList();
+        if (closePoints.Any())
+            return closePoints.First();
+        
         foreach (var point in trafficPositions)
         {
-            var closePoints = waypointsAroundHolding.Where(p => 
-                holdingPoints.Any(h => IsCloseEnough(p, h, 0.025))
-            ).ToList();
-            if (closePoints.Any())
-                return closePoints.First();
-
-            if (!waypointsAroundHolding.Any())
-                continue;
             foreach (var fixPoint in waypointsAroundHolding)
             {
                 var pointLonDiff = Math.Abs(fixPoint.Longitude - point.Lon);


### PR DESCRIPTION
Added a method that looks at the surrounding waypoints of a holding pattern to try and find the fix point of the holding pattern.
The method prioritizes the holding points found when identifying holding patterns, but if no waypoints are within a close enough range, it instead looks at all points in the holding pattern interval.
If it doesn't find any points that are close enough to a point in the line, it "creates" a fixpoint with the coordinates of the first inversion  point.

![image](https://user-images.githubusercontent.com/35064405/234554462-77729c8e-8d41-4b29-a8be-8d1ccafd4885.png)

The prioritization enables it to better distinguish between different suitable points, as the points closer to an actual identified holding point should have a higher likelihood of being a fix point. An example of this can be seen below, where it chooses the entry point to the holding pattern instead of the other point which is also close to the holding pattern:
![image](https://user-images.githubusercontent.com/35064405/234554870-eb0df101-2a87-4943-a440-8f59da62ff7b.png)
