### PR TITLE
Hotfix to automated data collection

### DIFF
--- a/FlightPatternDetection/Controllers/DebugController.cs
+++ b/FlightPatternDetection/Controllers/DebugController.cs
@@ -22,6 +22,33 @@ namespace FlightPatternDetection.Controllers
             _context = context;
         }
 
+        [HttpGet("GetAllErrorsFromAutomatedDb")]
+        public async Task<ActionResult> GetAllErrorsFromAutomatedDbAsync()
+        {
+            var errors = await _context.AutomatedCollection.Where(x => x.IsProcessed
+                                                        && x.DidHold == null
+                                                        && x.RawJson != null)
+                                                        .ToListAsync();
+            var textErrors = new List<string>();
+            foreach (var error in errors)
+            {
+                textErrors.Add($" - {error.FlightId}, fetched {error.Fetched}. Stored data (first 20 chars): {error.RawJsonAsString()?.Substring(0, 20)}...");
+            }
+            return Content("All Errors: \n" + string.Join("\n", textErrors));
+        }
+
+        [HttpGet("GetRawDataFromJsonFieldInDb")]
+        public async Task<ActionResult> GetRawDataFromJsonFieldInDb(long flightId)
+        {
+            var data = await _context.AutomatedCollection.FirstOrDefaultAsync(x => x.FlightId == flightId);
+            if (data is null)
+            {
+                return NotFound("FlightId did not exist in the database");
+            }
+
+            return Ok(data.RawJsonAsString());
+        }
+
         [HttpGet("waypoints")]
         public IEnumerable<EWayPoint> GetWaypoints(int count = 100)
         {

--- a/FlightPatternDetection/CronJobService/CronJobService.cs
+++ b/FlightPatternDetection/CronJobService/CronJobService.cs
@@ -50,6 +50,7 @@ namespace FlightPatternDetection.CronJobService
 
                 Log?.LogInformation($"CronJobService will fire next time: {next} (in approx. {delay.Days} day(s), {delay.Hours} hour(s) and {delay.Minutes} minutes)");
                 m_timer = new System.Timers.Timer(delay.TotalMilliseconds);
+                m_timer.AutoReset = false;
                 m_timer.Elapsed += async (sender, args) =>
                 {
                     m_timer.Dispose();  // reset and dispose timer

--- a/FlightPatternDetection/Program.cs
+++ b/FlightPatternDetection/Program.cs
@@ -31,7 +31,7 @@ namespace FlightPatternDetection
                 {
                     c.TimeZoneInfo = TimeZoneInfo.Utc;
                     c.RunImmediately = true;
-                    c.CronExpression = "0 * * * *"; //At the start of every hour
+                    c.CronExpression = "55 * * * *"; //Every :55 on the clock
                 });
 
                 builder.Services.AddCronJob<FlightAnalyzingTask>(c =>
@@ -57,7 +57,6 @@ namespace FlightPatternDetection
                     .UseMySql(connectionString, serverVersion)
                     // The following three options help with debugging, but should
                     // be changed or removed for production.
-                    .LogTo(Console.WriteLine, LogLevel.Information)
                     .EnableSensitiveDataLogging()
                     .EnableDetailedErrors()
             );

--- a/FlightPatternDetection/Services/FlightAccumulationTask.cs
+++ b/FlightPatternDetection/Services/FlightAccumulationTask.cs
@@ -22,6 +22,7 @@ namespace FlightPatternDetection.Services
 
         public async override Task DoWork(CancellationToken cancellationToken)
         {
+            await Task.Delay(5000);
             Log?.LogInformation("Fetching flight IDs");
             List<string> flightIdStr;
             try

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -11,3 +11,7 @@ echo "Built as 051153811601.dkr.ecr.us-east-1.amazonaws.com/anorup-bachelorproje
 echo "When ready, push using command below"
 echo ""
 echo "docker push 051153811601.dkr.ecr.us-east-1.amazonaws.com/anorup-bachelorproject:$1"
+echo ""
+echo "If you don't have credentials in Docker, or they expired, use the following command"
+echo ""
+echo "aws-vault exec ac-qa-poweruser -- aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 051153811601.dkr.ecr.us-east-1.amazonaws.com"


### PR DESCRIPTION
Turns out we have an error with some data. This adds error-handling, and logs the failed flights in the database.
They can be found with: 
```sql
SELECT * FROM `AutomatedCollection` WHERE `IsProcessed` = 1 AND `DidHold` IS NULL
```

New debug endpoints: `GetAllErrorsFromAutomatedDb` and `GetRawDataFromJsonFieldInDb` help you fetch this data and un-compress it so it's readable.

This branch is deployed. 